### PR TITLE
Add # to automerge commits to autolink to the PR

### DIFF
--- a/lib/bots/versionbot.ts
+++ b/lib/bots/versionbot.ts
@@ -828,7 +828,7 @@ export class VersionBot extends ProcBot {
     private mergeToMaster(data: MergeData, githubApiInstance: GithubApi): Promise<void> {
         return this.githubCall({
             data: {
-                commit_title: `Auto-merge for PR ${data.prNumber} via ${process.env.VERSIONBOT_NAME}`,
+                commit_title: `Auto-merge for PR #${data.prNumber} via ${process.env.VERSIONBOT_NAME}`,
                 number: data.prNumber,
                 owner: data.owner,
                 repo: data.repoName


### PR DESCRIPTION
The PR number is included in the commits, but without a `#`, so github doesn't link to it from commit messages, which makes finding the PR from the commit _slightly_ annoying. Almost as easy to fix it as to file an issue, so I've just done it. Untested, since I'm not sure how to, but seems pretty clear cut.