### PR TITLE
SyncBot: Tie metadata to the message it pertains to

### DIFF
--- a/configs/syncbot_prod.yml
+++ b/configs/syncbot_prod.yml
@@ -108,5 +108,6 @@ SYNCBOT_METADATA_CONFIG:
     hidden: "whisper"
     hiddenPreferred: "murmur"
     shown: "reply"
+  secret: "<<INJECT_SYNCBOT_SECRET>>"
 SYNCBOT_NAME: "<<INJECT_SYNCBOT_NAME>>"
 SYNCBOT_PORT: "<<INJECT_SYNCBOT_PORT>>"

--- a/configs/syncbot_test.yml
+++ b/configs/syncbot_test.yml
@@ -89,5 +89,6 @@ SYNCBOT_METADATA_CONFIG:
     hidden: "whisper"
     hiddenPreferred: "murmur"
     shown: "reply"
+  secret: "<<INJECT_SYNCBOT_SECRET>>"
 SYNCBOT_NAME: "<<INJECT_SYNCBOT_NAME>>"
 SYNCBOT_PORT: "<<INJECT_SYNCBOT_PORT>>"

--- a/lib/services/messenger/translators/translator-scaffold.ts
+++ b/lib/services/messenger/translators/translator-scaffold.ts
@@ -207,16 +207,17 @@ export abstract class TranslatorScaffold implements Translator {
 	 */
 	public static metadataByRegex(message: string, regex: RegExp, indicators: PublicityIndicators): TranslatorMetadata {
 		const metadata = message.match(regex);
+		const content = TranslatorScaffold.unixifyNewLines(message.replace(regex, '').trim());
 		if (metadata) {
 			return {
-				content: TranslatorScaffold.unixifyNewLines(message.replace(regex, '').trim()),
+				content,
 				flow: metadata[3] || null,
 				service: metadata[2] || null,
 				hidden: TranslatorScaffold.findPublicityFromWord(metadata[1], indicators),
 				thread: metadata[4] || null,
 			};
 		}
-		return TranslatorScaffold.emptyMetadata(TranslatorScaffold.unixifyNewLines(message.trim()));
+		return TranslatorScaffold.emptyMetadata(content);
 	}
 
 	/**

--- a/lib/services/messenger/translators/translator-scaffold.ts
+++ b/lib/services/messenger/translators/translator-scaffold.ts
@@ -195,7 +195,7 @@ export abstract class TranslatorScaffold implements Translator {
 		message: string, format: MetadataEncoding, config: MetadataConfiguration,
 	): TranslatorMetadata {
 		const words = `(${_.values(config.publicity).join('|')})`;
-		const querystring = `\\?hidden=${words}&source=(\\w*)&flow=([^"\\)]*)&thread=([^"\\)]*)`;
+		const querystring = `\\?hidden=${words}&source=(\\w*)&flow=([^"&\\)]*)&thread=([^"&\\)]*)`;
 		const baseUrl = _.escapeRegExp(config.baseUrl);
 		const publicity = config.publicity;
 		switch (format) {

--- a/lib/services/messenger/translators/translator-scaffold.ts
+++ b/lib/services/messenger/translators/translator-scaffold.ts
@@ -207,6 +207,21 @@ export abstract class TranslatorScaffold implements Translator {
 	}
 
 	/**
+	 * Return an empty metadata object, for occasions where there is no metadata
+	 * @param content  Content, if any, that originated this empty object.
+	 * @returns        An empty metadata object.
+	 */
+	public static emptyMetadata(content?: string): TranslatorMetadata {
+		return {
+			content: content || '',
+			flow: null,
+			service: null,
+			hidden: true,
+			thread: null,
+		};
+	}
+
+	/**
 	 * A dictionary of messenger event names, eg post, into service specific events, eg inbound_message, outbound_message.
 	 */
 	protected abstract eventEquivalencies: EventEquivalencies;

--- a/lib/services/messenger/translators/translator-scaffold.ts
+++ b/lib/services/messenger/translators/translator-scaffold.ts
@@ -216,13 +216,7 @@ export abstract class TranslatorScaffold implements Translator {
 				thread: metadata[4] || null,
 			};
 		}
-		return {
-			content: TranslatorScaffold.unixifyNewLines(message.trim()),
-			flow: null,
-			service: null,
-			hidden: true,
-			thread: null,
-		};
+		return TranslatorScaffold.emptyMetadata(TranslatorScaffold.unixifyNewLines(message.trim()));
 	}
 
 	/**
@@ -230,9 +224,9 @@ export abstract class TranslatorScaffold implements Translator {
 	 * @param content  Content, if any, that originated this empty object.
 	 * @returns        An empty metadata object.
 	 */
-	public static emptyMetadata(content?: string): TranslatorMetadata {
+	public static emptyMetadata(content: string = ''): TranslatorMetadata {
 		return {
-			content: content || '',
+			content,
 			flow: null,
 			service: null,
 			hidden: true,

--- a/lib/services/messenger/translators/translator-types.d.ts
+++ b/lib/services/messenger/translators/translator-types.d.ts
@@ -29,6 +29,8 @@ export interface TranslatorMetadata {
 	hidden: PrivacyPreference;
 	/** Thread ID that this message was created on. */
 	thread: string | null;
+	/** Signature of the words in the associated message. */
+	hmac?: string | null;
 }
 
 export interface PublicityIndicators {
@@ -40,6 +42,7 @@ export interface PublicityIndicators {
 export interface MetadataConfiguration {
 	baseUrl: string;
 	publicity: PublicityIndicators;
+	secret: string;
 }
 
 /** Mapping of generic names for an event into equivalent specific events. */

--- a/tests/services/messenger/translators/front.spec.ts
+++ b/tests/services/messenger/translators/front.spec.ts
@@ -18,7 +18,8 @@ describe('lib/services/messenger/translators/front.ts', () => {
 					hidden: 'whisper',
 					hiddenPreferred: 'murmur',
 					shown: 'reply',
-				}
+				},
+				secret: 'salt',
 			};
 			const target = {
 				action: 1,

--- a/tests/services/messenger/translators/translator-scaffold.spec.ts
+++ b/tests/services/messenger/translators/translator-scaffold.spec.ts
@@ -82,6 +82,40 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 		});
 	});
 
+	describe('TranslatorScaffold.extractWords', () => {
+		it('should find the words in a simple message', () => {
+			expect(TranslatorScaffold.extractWords('test this')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should remove grammar, including upper case', () => {
+			expect(TranslatorScaffold.extractWords('Test this.')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should remove simple html tags', () => {
+			expect(TranslatorScaffold.extractWords('<p>test this</p>')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should remove complex html tags', () => {
+			expect(TranslatorScaffold.extractWords('<a href="blah">test<br/>this</a>')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should ignore invisible html', () => {
+			expect(TranslatorScaffold.extractWords('test this<a href="blah"></a>')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should remove simple markdown', () => {
+			expect(TranslatorScaffold.extractWords('**test this**')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should remove complex markdown', () => {
+			expect(TranslatorScaffold.extractWords('[test](blah)\n\n* this')).to.deep.equal(['test', 'this']);
+		});
+
+		it('should ignore invisible markdown', () => {
+			expect(TranslatorScaffold.extractWords('test this\n\n[](blah)')).to.deep.equal(['test', 'this']);
+		});
+	});
+
 	describe('TranslatorScaffold.stringifyMetadata', () => {
 		const exampleMessage = {
 			details: {

--- a/tests/services/messenger/translators/translator-scaffold.spec.ts
+++ b/tests/services/messenger/translators/translator-scaffold.spec.ts
@@ -4,6 +4,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
+import * as crypto from 'crypto';
 import {
 	MetadataEncoding,
 	TranslatorScaffold,
@@ -18,6 +19,7 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 			hiddenPreferred: 'murmur',
 			shown: 'reply',
 		},
+		secret: 'salt',
 	};
 
 	describe('TranslatorScaffold.convertPings', () => {
@@ -117,6 +119,7 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 	});
 
 	describe('TranslatorScaffold.stringifyMetadata', () => {
+		const hmac = crypto.createHmac('sha256', 'salt').update('c').digest('hex');
 		const exampleMessage = {
 			details: {
 				service: 'a',
@@ -142,7 +145,8 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 				MetadataEncoding.HiddenMD,
 				exampleConfig,
 			);
-			expect(encodedMetadata).to.equal('[](http://e.com?hidden=whisper&source=g&flow=i&thread=f)');
+			const expectedString = `[](http://e.com?hidden=whisper&source=g&flow=i&thread=f&hmac=${hmac})`;
+			expect(encodedMetadata).to.equal(expectedString);
 		});
 
 		it('should encode metadata into an invisible link html string', () => {
@@ -151,39 +155,54 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 				MetadataEncoding.HiddenHTML,
 				exampleConfig,
 			);
-			expect(encodedMetadata).to.equal('<a href="http://e.com?hidden=whisper&source=g&flow=i&thread=f"></a>');
+			const expectedString = `<a href="http://e.com?hidden=whisper&source=g&flow=i&thread=f&hmac=${hmac}"></a>`;
+			expect(encodedMetadata).to.equal(expectedString);
+		});
+	});
+
+	describe('TranslatorScaffold.signText', () => {
+		const hmac = crypto.createHmac('sha256', 'salt').update('h').digest('hex');
+
+		it('should correctly hash a provided object', () => {
+			const hash = TranslatorScaffold.signText('h', exampleConfig.secret);
+			expect(hash).to.equal(hmac);
 		});
 	});
 
 	describe('TranslatorScaffold.extractMetadata', () => {
+		const hmac = crypto.createHmac('sha256', 'salt').update('h').digest('hex');
+		const expectedObject = { content: 'h', hidden: true, service: 'g', flow: 'j', thread: 'i', hmac };
+
 		it('should extract metadata from a markdown-at-end string', () => {
 			const extractedMetadata = TranslatorScaffold.extractMetadata(
-				'h[](http://e.com?hidden=whisper&source=g&flow=j&thread=i)',
+				`h[](http://e.com?hidden=whisper&source=g&flow=j&thread=i&hmac=${hmac})`,
 				MetadataEncoding.HiddenMD,
 				exampleConfig,
 			);
-			expect(extractedMetadata).to.deep.equal({content: 'h', hidden: true, service: 'g', flow: 'j', thread: 'i'});
+			expect(extractedMetadata).to.deep.equal(expectedObject);
 		});
 
 		it('should extract metadata from a html-at-end string', () => {
 			const extractedMetadata = TranslatorScaffold.extractMetadata(
-				'h<a href="http://e.com?hidden=whisper&source=g&flow=j&thread=i"></a>',
+				`h<a href="http://e.com?hidden=whisper&source=g&flow=j&thread=i&hmac=${hmac}"></a>`,
 				MetadataEncoding.HiddenHTML,
 				exampleConfig,
 			);
-			expect(extractedMetadata).to.deep.equal({content: 'h', hidden: true, service: 'g', flow: 'j', thread: 'i'});
+			expect(extractedMetadata).to.deep.equal(expectedObject);
 		});
 
 		it('should not extract metadata from an html-in-qouted-text string', () => {
+			const copiedMessage = `h<a href="http://e.com?hidden=whisper&source=g&flow=j&thread=i&hmac=${hmac}"></a>`;
 			const extractedMetadata = TranslatorScaffold.extractMetadata(
-				'<div>Their reply.</div><div>h<a href="http://e.com?hidden=whisper&source=g&flow=j&thread=i"></a></div>',
+				`<div>Their reply.</div><div>${copiedMessage}</div>`,
 				MetadataEncoding.HiddenHTML,
 				exampleConfig,
 			);
 			expect(extractedMetadata).to.deep.equal({
-				content: '<div>Their reply.</div><div>h<a href="http://e.com?hidden=whisper&source=g&flow=j&thread=i"></a></div>',
+				content: `<div>Their reply.</div><div>${copiedMessage}</div>`,
 				hidden: true,
 				service: null,
+				hmac: null,
 				flow: null,
 				thread: null,
 			});
@@ -193,11 +212,12 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 	describe('TranslatorScaffold.metadataByRegex', () => {
 		it('should find metadata matches in a string based on a provided regex', () => {
 			const extractedMetadata = TranslatorScaffold.metadataByRegex(
-				'blah,reply,e,d,f',
-				/,(\w*),(\w*),(\w*),(\w*)$/,
+				'blah,reply,e,d,f,g',
+				/,(\w*),(\w*),(\w*),(\w*),(\w*)$/,
 				exampleConfig.publicity,
 			);
-			expect(extractedMetadata).to.deep.equal({content: 'blah', hidden: false, service: 'e', flow: 'd', thread: 'f'});
+			const expectedOutput = {content: 'blah', hidden: false, service: 'e', flow: 'd', thread: 'f', hmac: 'g'};
+			expect(extractedMetadata).to.deep.equal(expectedOutput);
 		});
 	});
 });


### PR DESCRIPTION
* Use the below to tie metadata to message content
* Add methods to calculate the words and from that hmac of a message
* While I was there improved the logging of a new thread to use thread title

Change-Type: patch
Connects-To: #358

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output been rebuilt and tested
- [ ] Introduces security considerations
- [x] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
---- Autogenerated Waffleboard Connection: Connects to #358