### PR TITLE
SyncBot: Fix hyphenated content causing repeated messages

### DIFF
--- a/lib/services/messenger/translators/translator-scaffold.ts
+++ b/lib/services/messenger/translators/translator-scaffold.ts
@@ -102,7 +102,7 @@ export abstract class TranslatorScaffold implements Translator {
 		// Remove any html tags
 		const cleanedString = htmlString.replace(/<[^>]*>/g, ' ');
 		// Break the string down to word sections
-		return cleanedString.match(/\w+/g) || [];
+		return cleanedString.match(/[a-zA-Z]+/g) || [];
 	}
 
 	/**

--- a/tests/services/messenger/translators/translator-scaffold.spec.ts
+++ b/tests/services/messenger/translators/translator-scaffold.spec.ts
@@ -102,6 +102,10 @@ describe('lib/services/messenger/translators/translator-scaffold.ts', () => {
 			expect(TranslatorScaffold.extractWords('test this')).to.deep.equal(['test', 'this']);
 		});
 
+		it('should find the words in a message that contains hyphens and underscores', () => {
+			expect(TranslatorScaffold.extractWords('test-this_')).to.deep.equal(['test', 'this']);
+		});
+
 		it('should remove grammar, including upper case', () => {
 			expect(TranslatorScaffold.extractWords('Test this.')).to.deep.equal(['test', 'this']);
 		});


### PR DESCRIPTION
* Replace \w in word extractor with [a-z][A-Z]
* Fix hyphenated content causing repeated messages

Change-Type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output been rebuilt and tested
- [ ] Introduces security considerations
- [x] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
