### PR TITLE
SyncBot: Fix image url translation

### DIFF
--- a/lib/services/messenger/translators/discourse.ts
+++ b/lib/services/messenger/translators/discourse.ts
@@ -466,7 +466,14 @@ export class DiscourseTranslator extends TranslatorScaffold implements Translato
 				if (!imgAlt) {
 					return fullMatch;
 				}
-				return images[imgAlt[1]];
+				// /uploads/this.png is relative and does not have protocol
+				// http://example.com/uploads/this.png is not relative and has protocol
+				// //localhost/uploads/this.png is not relative and does not have protocol
+				const hasProtocol = /^\w+:/.test(images[imgAlt[1]]); // Begins with some letters, then :
+				const protocolFiller = hasProtocol ? '' : `${this.connectionDetails.protocol || 'https'}:`;
+				const isRelative = /^\/[^\/]/.test(images[imgAlt[1]]); // Begins with a / then not a /
+				const serverFiller = isRelative ? `//${this.connectionDetails.instance}` : '';
+				return `${protocolFiller}${serverFiller}${images[imgAlt[1]]}`;
 			});
 			const quoteFinder = /\[quote="([^,"]*).*"]\s*([\s\S]*)\[\/quote]/;
 			const quoteParsedText = imgReplacedText.replace(new RegExp(quoteFinder, 'gm'), (fullMatch) => {

--- a/lib/services/messenger/translators/flowdock.ts
+++ b/lib/services/messenger/translators/flowdock.ts
@@ -455,7 +455,7 @@ export class FlowdockTranslator extends TranslatorScaffold implements Translator
 	}
 
 	protected eventEquivalencies = {
-		message: ['message'],
+		message: ['message', 'file'],
 	};
 	protected emitConverters: EmitConverters = {
 		[MessengerAction.ReadConnection]: FlowdockTranslator.readThreadIntoEmit,
@@ -504,6 +504,9 @@ export class FlowdockTranslator extends TranslatorScaffold implements Translator
 	 * @returns      Promise that resolves to an array of message objects in the standard form
 	 */
 	public eventIntoMessages(event: FlowdockEvent): Promise<MessengerEvent[]> {
+		if (event.type === 'file') {
+			event.rawEvent.content = this.fullyQualifyPath(event.rawEvent.content.path);
+		}
 		const details = this.eventIntoMessageDetails(event);
 		// Start building this in service scaffold form.
 		const cookedEvent: BasicMessageInformation = {
@@ -635,6 +638,10 @@ export class FlowdockTranslator extends TranslatorScaffold implements Translator
 				title: metadata.title,
 			}
 		};
+	}
+
+	private fullyQualifyPath(path: string): string {
+		return `https://www.flowdock.com/rest${path}`;
 	}
 }
 


### PR DESCRIPTION
* Prepend server details when discourse translates an image url
* Prepend flowdock path when flowdock translates a file
* Cannot perform similar translation for Front, because Front
  * Seriously, their UI uses a different version of the API to everyone else, and everyone else doesn't have access to attachments.

Change-Type: patch
Connects-To: #547

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
---- Autogenerated Waffleboard Connection: Connects to #547