### PR TITLE
SyncBot: Preserve single new lines from Forums into Front

### DIFF
--- a/lib/services/messenger/translators/front.ts
+++ b/lib/services/messenger/translators/front.ts
@@ -427,9 +427,16 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 			);
 			const converter = FrontTranslator.convertUsernameToFront;
 			const messageString = TranslatorScaffold.convertPings(messageDetails.text, converter);
+			const messageHTML = marked(
+				messageString,
+				{
+					gfm: true, // github-flavoured-markdown
+					breaks: true, // with line breaks and paragraphs
+				},
+			);
 			const createMessageData: MessageRequest.Reply = {
 				author_id: userId,
-				body: `${marked(messageString)}${metadataInjection}`,
+				body: `${messageHTML}${metadataInjection}`,
 				conversation_id: threadId,
 				options: {
 					archive: false,


### PR DESCRIPTION
Instruct `marked` to use github flavoured markdown with both line
breaks and paragraph breaks when translating to Front.

Change-type: patch
Connects-to: #585
Signed-off-by: Andrew Lucas <andrewl@resin.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
