### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "resin-sdk": "^6.4.1",
-    "resin-semver": "^0.9.2",
+    "resin-semver": "^1.4.0",
     "rmdir": "^1.2.0",
     "temp": "^0.8.3",
     "typed-error": "^1.0.1",


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)
