### PR TITLE
Fix PayloadTooLargeError errors

### DIFF
--- a/lib/bots/keyframebot.ts
+++ b/lib/bots/keyframebot.ts
@@ -236,8 +236,8 @@ export class KeyframeBot extends ProcBot {
 		}
 
 		// Add body parser.
-		this.expressApp.use(bodyParser.urlencoded({ extended: true }));
-		this.expressApp.use(bodyParser.json());
+		this.expressApp.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }));
+		this.expressApp.use(bodyParser.json({ limit: '50mb' }));
 		this.expressApp.post(DeployKeyframePath, this.deployKeyframe);
 
 		// Listen.

--- a/lib/services/github.ts
+++ b/lib/services/github.ts
@@ -576,8 +576,8 @@ export class GithubService extends WorkerClient<string> implements ServiceListen
 	private getExpressInstance(server: number | express.Express): express.Express {
 		if (_.isNumber(server)) {
 			const app = express();
-			app.use(bodyParser.urlencoded({ extended: true }));
-			app.use(bodyParser.text({type: '*/*'}));
+			app.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }));
+			app.use(bodyParser.text({ type: '*/*', limit: '50mb' }));
 			app.listen(server, () => {
 				this.logger.log(LogLevel.INFO, `---> Created Express app on port ${server} for '${this.serviceName}'.`);
 			});

--- a/lib/services/service-scaffold.ts
+++ b/lib/services/service-scaffold.ts
@@ -96,7 +96,7 @@ export abstract class ServiceScaffold<T> extends WorkerClient<T> implements Serv
 				const port = data.ingress;
 				this.expressApp = express();
 				// This passes to the inheriting class responsibility for understanding the payload structure.
-				this.expressApp.use(bodyParser.text({type: '*/*'}));
+				this.expressApp.use(bodyParser.text({ type: '*/*', limit: '50mb' }));
 				this.expressApp.listen(port);
 				this.logger.log(LogLevel.INFO, `---> Created Express app on port ${port} for '${this.serviceName}'.`);
 			} else if (data.ingress) {


### PR DESCRIPTION
Syncbot logs report 'PayloadTooLargeError: request entity too large'
in several places that perfectly coincide with lost messages. For all
messages that I checked these indeed were large Front messages,
resulting from big email threads were the response contained all the
previous responses quoted.

Also fixed this for github services and keyframebot, even though these
are not currently used, to save us from hitting the same error if we
ever re-enable them.

Fixes #621 
Change-type: patch
Singed-off-by: Kostas Lekkas <kostas@balena.io>
